### PR TITLE
Expose asserters

### DIFF
--- a/lib/wd-sync.coffee
+++ b/lib/wd-sync.coffee
@@ -76,6 +76,9 @@ patch = (browser) ->
 
 wdSync =
   SPECIAL_KEYS: wd.SPECIAL_KEYS
+
+  asserters: wd.asserters
+
   # similar to wd
   remote: (args...) ->
     browser = wd.remote args...

--- a/lib/wd-sync.js
+++ b/lib/wd-sync.js
@@ -121,6 +121,7 @@
 
   wdSync = {
     SPECIAL_KEYS: wd.SPECIAL_KEYS,
+    asserters: wd.asserters,
     remote: function() {
       var args, browser;
       args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];


### PR DESCRIPTION
Asserters are used for all the `waitFor` calls now. 
