### PR TITLE
Add .rawElement to sync-wrapped return elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ client for node.js, built using  [node-fibers](http://github.com/laverdet/node-f
 
 Note: headless zombie was removed in 1.1.0
 
+Note: Elements returned from synchronized methods are wrapped in synchronization code as well. If you need to access the original, untouched element, you can reference it via the `.rawElement` property. E.g.:
+
+```
+var element = browser.elementByCssSelector('#myElement');
+browser.execute('arguments[0].className += " hidden"', [element.rawElement]);
+```
+
 ## status
 
 [![Build Status](https://travis-ci.org/sebv/node-wd-sync.png)](https://travis-ci.org/sebv/node-wd-sync)


### PR DESCRIPTION
The sync magic being wrapped around returned elements breaks compatibility with wd — in particular, an element returned by wd-sync cannot be passed on as an argument to code in  `.execute(Async)()` as it's no longer a valid element for serialization.
