### PR TITLE
Add .rawElement to sync-wrapped return elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ client for node.js, built using  [node-fibers](http://github.com/laverdet/node-f
 
 Note: headless zombie was removed in 1.1.0
 
+Note: Elements returned from synchronized methods are wrapped in synchronization code as well. If you need to access the original, untouched element, you can reference it via the `.rawElement` property. E.g.:
+
+```
+var element = browser.elementByCssSelector('#myElement');
+browser.execute('arguments[0].className += " hidden"', [element.rawElement]);
+```
+
 ## status
 
 [![Build Status](https://travis-ci.org/sebv/node-wd-sync.png)](https://travis-ci.org/sebv/node-wd-sync)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # wd-sync
 
-**A synchronous version with a nice api of [wd](http://github.com/admc/wd), 
-the lightweight  [WebDriver / Selenium2](http://seleniumhq.org/projects/webdriver/) 
+**A synchronous version with a nice api of [wd](http://github.com/admc/wd),
+the lightweight  [WebDriver / Selenium2](http://seleniumhq.org/projects/webdriver/)
 client for node.js, built using  [node-fibers](http://github.com/laverdet/node-fibers).**
 
 [Site](http://sebv.github.io/node-wd-sync/)
 
 Note: headless zombie was removed in 1.1.0
 
-Note: Elements returned from synchronized methods are wrapped in synchronization code as well. If you need to access the original, untouched element, you can reference it via the `.rawElement` property. E.g.:
+"Raw" fork: This version is a drop-in replacement for the official [node-wd-sync](https://travis-ci.org/sebv/node-wd-sync) with one additional feature: In node-wd-sync, elements returned from synchronized methods are wrapped in synchronization code as well. This fork provides access to the original, untouched element, which you can reference via the `.rawElement` property in cases where you need to access the unmodified element. E.g.:
 
 ```
 var element = browser.elementByCssSelector('#myElement');
@@ -62,7 +62,7 @@ sync ->
 
   @quit()
 
-```        
+```
 
 ### JavaScript
 
@@ -101,9 +101,9 @@ sync( function() {
 
 });
 
-``` 
+```
 
-## doc 
+## doc
 
 * [CoffeeScript](http://github.com/sebv/node-wd-sync/blob/master/doc/COFFEE-DOC.md)
 * [JavaScript](http://github.com/sebv/node-wd-sync/blob/master/doc/JS-DOC.md)
@@ -122,10 +122,10 @@ Note: Doc and README modifications must be done in the doc/template directory.
 [supported](http://github.com/sebv/node-wd-sync/blob/master/doc/jsonwire-mapping.md)
 
 [full JsonWireProtocol mapping](http://github.com/sebv/node-wd-sync/blob/master/doc/jsonwire-full-mapping.md)
-  
+
 ## available environments
 
-### WebDriver 
+### WebDriver
 
 local [WebDriver / Selenium2](http://seleniumhq.org/projects/webdriver/) server
 
@@ -135,7 +135,7 @@ Remote testing with [Sauce Labs](http://saucelabs.com).
 
 ## running tests
 
-### local / selenium server: 
+### local / selenium server:
 
 1/ Install and start Selenium server
 
@@ -147,10 +147,10 @@ Remote testing with [Sauce Labs](http://saucelabs.com).
 
 2/ run tests
 ```
-make test 
+make test
 ```
 
-### remote / Sauce Labs 
+### remote / Sauce Labs
 
 1/ configure sauce environment
 ```

--- a/lib/wd-sync.coffee
+++ b/lib/wd-sync.coffee
@@ -45,7 +45,7 @@ wrapSync = (target) ->
     do ->
       target[k] = makeSync target[k], mode:['mixed', 'args']
 
-  # wrapping methods to make returned elements synchronous
+  # wrapping methods to make returned elements synchronous while keeping a reference to the raw element
   wrappedTarget = {}
   for k,v of target when (typeof v) is 'function'
     do ->
@@ -53,11 +53,18 @@ wrapSync = (target) ->
       wrappedTarget[k] = (args...) ->
         res = _v.apply target, args
         # single element returned
-        res = wrapSync res if isElement res
+        if isElement res
+          raw = res
+          res = wrapSync res
+          res.rawElement = raw
         # array element returned
         if _(res).isArray()
           res = _.map res, (val) ->
-            if isElement val then wrapSync val else val
+            if isElement val
+              raw = val
+              val = wrapSync val
+              val.rawElement = raw
+            val
         res
   wrappedTarget
 

--- a/lib/wd-sync.js
+++ b/lib/wd-sync.js
@@ -79,19 +79,22 @@
           var _v;
           _v = v;
           return wrappedTarget[k] = function() {
-            var args, res;
+            var args, raw, res;
             args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
             res = _v.apply(target, args);
             if (isElement(res)) {
+              raw = res;
               res = wrapSync(res);
+              res.rawElement = raw;
             }
             if (_(res).isArray()) {
               res = _.map(res, function(val) {
                 if (isElement(val)) {
-                  return wrapSync(val);
-                } else {
-                  return val;
+                  raw = val;
+                  val = wrapSync(val);
+                  val.rawElement = raw;
                 }
+                return val;
               });
             }
             return res;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "wd-sync",
+  "name": "wd-sync-raw",
   "version": "1.2.5",
-  "description": "sync version of wd using fibers.",
+  "description": "sync version of wd using fibers with .rawElement work-around for compatibility with .execute methods.",
   "keywords": [
     "selenium",
     "webdriver",
@@ -9,10 +9,10 @@
     "fibers",
     "sync"
   ],
-  "author": "Seb Vincent <seb.vincent@gmail.com>",
+  "author": "Daniel Smedegaard Buus <danielbuus@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sebv/node-wd-sync.git"
+    "url": "git+https://github.com/DanielSmedegaardBuus/node-wd-sync.git"
   },
   "main": "./index",
   "engine": "node >= 0.6.1",
@@ -36,5 +36,15 @@
     "chai": "~1.8.1",
     "hbs": "~2.4.0",
     "request": "~2.27.0"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/DanielSmedegaardBuus/node-wd-sync/issues"
+  },
+  "homepage": "https://github.com/DanielSmedegaardBuus/node-wd-sync#readme",
+  "directories": {
+    "doc": "doc",
+    "example": "examples",
+    "test": "test"
+  },
+  "license": "ISC"
 }


### PR DESCRIPTION
The sync magic being wrapped around returned elements breaks compatibility with wd — in particular, an element returned by wd-sync cannot be passed on as an argument to code in  `.execute(Async)()` as it's no longer a valid element for serialization.
